### PR TITLE
Start a project dir using opam2nix (broken).

### DIFF
--- a/nix-dev/simple/dune-project
+++ b/nix-dev/simple/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.11)
+(name mysimple)

--- a/nix-dev/simple/mysimple.opam
+++ b/nix-dev/simple/mysimple.opam
@@ -1,0 +1,11 @@
+opam-version: "2.0"
+authors: [ "jwatt@broken.watch" ]
+homepage: "https://github.com/jjwatt/play-ocaml"
+maintainer: "jwatt@broken.watch"
+depends: [
+  "lwt" { >= "2.5.1" }
+          "dune" {build}
+]
+build: [
+  [ "dune" "build" "-p" "mysimple" ]
+]

--- a/nix-dev/simple/opam2nix.nix
+++ b/nix-dev/simple/opam2nix.nix
@@ -1,0 +1,1 @@
+import (builtins.fetchTarball "https://github.com/timbertson/opam2nix/archive/v1.tar.gz") {}

--- a/nix-dev/simple/src/dune
+++ b/nix-dev/simple/src/dune
@@ -1,0 +1,5 @@
+(executable
+ (name main)
+ (public_name main)
+ (libraries lwt lwt.unix)
+)

--- a/nix-dev/simple/src/main.ml
+++ b/nix-dev/simple/src/main.ml
@@ -1,0 +1,10 @@
+let hello_async () =
+	let open Lwt in
+	print_endline "sleeping...";
+	Lwt_unix.sleep 0.1 >>= fun () ->
+	print_endline "done!";
+	return_unit
+
+let () =
+	Lwt_main.run (hello_async ())
+


### PR DESCRIPTION
I'm saving this, but it appears that opam2nix doesn't work for me. I even tried
checking opam2nix out into its own git dir to run its examples. Its examples
didn't run in a submodule dir because of stuff that it does with nix-wrangle and
looking for a HEAD ref. But, that's not the main point. Following the directions
for a project didn't get past the point of trying to install the opam2nix
package from the tar.gz from the import expression.

There's an ocaml2nix, too, apparently. I haven't tried it yet. The main thing
I'd like to get working is doing something similar to `haskell-nix` where I can
install the package through nix, but also build and test it using the opam
infrastructure. Ideally, I could setup nix stuff that can use newer versions of
ocaml, even from HEAD, and newer versions of packages from opam.